### PR TITLE
Only call tsconfig-glob if there is a filesGlob present in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.0",
-    "tsconfig-glob": "^0.1.3",
+    "tsconfig-glob": "^0.2.1",
     "typescript": "^1.5.3"
   },
   "bugs": {

--- a/tasks/typescriptUsingTsConfig.js
+++ b/tasks/typescriptUsingTsConfig.js
@@ -18,11 +18,16 @@ module.exports = function (grunt) {
         console.log('New tsconfig.json was created at', tsconfigPath);
       }
 
-      tsconfigGlob({
-        configPath: options.rootDir,
-        cwd: process.cwd(),
-        indent: 2
-      });
+      var tsconfigContents = grunt.file.readJSON(tsconfigPath);
+
+      // only call tsconfigGlob if there is a glob pattern in tsconfig.json
+      if (tsconfigContents.filesGlob) {
+        tsconfigGlob({
+          configPath: options.rootDir,
+          cwd: process.cwd(),
+          indent: 2
+        });
+      }
     }
 
     function getTypeScriptCompilerBinPath() {


### PR DESCRIPTION
I mostly use this task to simply run tsc from grunt on my project. Nowadays tsc can scan subfolders for all .ts files so glob is not always needed. One can use "exclude" property in tsconfig.json and not specify "files" property and tsc will pick up all .ts files for building. Unfortunately tsconfig-glob package will write an empty "files" property in tsconfig.json which prevents tsc from recursively looking in subfolders. This change prevents calling tsconfig-glob package if there is no "filesGlob" property in tsconfig.json.
